### PR TITLE
Move [trivial_progress] earlier in [quick_analysis].

### DIFF
--- a/src/dynamic.cpp
+++ b/src/dynamic.cpp
@@ -334,9 +334,12 @@ DYNAMIC::SearchResult DYNAMIC::full_analysis(Position& pos, DYNAMIC::Search& sea
   if (!search.is_interrupted() && !mate)
     search.set_unwinnable();
 
-  if (search.get_result() == DYNAMIC::UNDETERMINED)
-    if (SemiStatic::is_unwinnable(pos, search.intended_winner(), 0))
+  if (search.get_result() == DYNAMIC::UNDETERMINED) {
+    StateInfo st;
+    UTIL::trivial_progress(pos, st, 100);
+    if (SemiStatic::is_unwinnable(pos, search.intended_winner()))
       search.set_unwinnable();
+  }
 
   if (search.get_result() == DYNAMIC::UNDETERMINED) {
     TT.clear();
@@ -377,6 +380,8 @@ DYNAMIC::SearchResult DYNAMIC::quick_analysis(Position& pos, DYNAMIC::Search& se
   bool onlyPawnsAndBishops = !KRQ;
   bool almostOnlyPawnsAndBishops = popcount(KRQ) <= 1;
 
+  StateInfo st;
+  UTIL::trivial_progress(pos, st, 100);
   unwinnable = dynamically_unwinnable(pos, 9, search.intended_winner(), search);
 
   bool blockedCandidate =
@@ -384,7 +389,7 @@ DYNAMIC::SearchResult DYNAMIC::quick_analysis(Position& pos, DYNAMIC::Search& se
     !UTIL::has_lonely_pawns(pos);
 
   if (blockedCandidate && !unwinnable && onlyPawnsAndBishops)
-    if (SemiStatic::is_unwinnable(pos, search.intended_winner(), 0))
+    if (SemiStatic::is_unwinnable(pos, search.intended_winner()))
       unwinnable = true;
 
   if (blockedCandidate && !unwinnable &&
@@ -403,7 +408,7 @@ DYNAMIC::SearchResult DYNAMIC::find_shortest(Position& pos, DYNAMIC::Search& sea
   bool mate;
   search.init();
 
-  if (SemiStatic::is_unwinnable(pos, search.intended_winner(), 0))
+  if (SemiStatic::is_unwinnable(pos, search.intended_winner()))
     search.set_unwinnable();
 
   TT.clear();

--- a/src/semistatic.cpp
+++ b/src/semistatic.cpp
@@ -380,8 +380,7 @@ void SemiStatic::init() {
 
 // Check if the position is semistatically unwinnable.
 
-bool SemiStatic::is_unwinnable(Position& pos, Color intendedWinner,
-                               int trivialProgressBound) {
+bool SemiStatic::is_unwinnable(Position& pos, Color intendedWinner) {
 
   // Checkmate or Stalemate
   if (MoveList<LEGAL>(pos).size() == 0)
@@ -391,18 +390,6 @@ bool SemiStatic::is_unwinnable(Position& pos, Color intendedWinner,
   for (const auto& m : MoveList<LEGAL>(pos))
     if (type_of(m) == ENPASSANT)
       return false;
-
-  // Trivial progress: as long as there is only one legal move, make that move
-  // (But at most 100 times, to avoid infinite loops)
-  StateInfo st;
-  if (MoveList<LEGAL>(pos).size() == 1 && trivialProgressBound < 100)
-    for (const auto& m : MoveList<LEGAL>(pos)) {
-      pos.do_move(m, st);
-      bool unwinnable = SemiStatic::is_unwinnable(pos, intendedWinner,
-                                                  trivialProgressBound+1);
-      pos.undo_move(m);
-      return unwinnable;
-    }
 
   SYSTEM.saturate(pos);
   return SYSTEM.is_unwinnable(pos, intendedWinner);
@@ -420,7 +407,7 @@ bool SemiStatic::is_unwinnable_after_one_move(Position& pos,
   StateInfo st;
   for (const auto& m : MoveList<LEGAL>(pos)) {
     pos.do_move(m,st);
-    if (!is_unwinnable(pos, intendedWinner, 0))
+    if (!is_unwinnable(pos, intendedWinner))
       return false;
     pos.undo_move(m);
   }

--- a/src/semistatic.h
+++ b/src/semistatic.h
@@ -96,8 +96,7 @@ namespace SemiStatic {
 
   void init();
 
-  bool is_unwinnable(Position& pos, Color intendedWinner,
-                     int trivialProgressBound);
+  bool is_unwinnable(Position& pos, Color intendedWinner);
   bool is_unwinnable_after_one_move(Position& pos, Color intendedWinner);
 
 } // namespace SemiStatic

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -130,6 +130,19 @@ bool UTIL::is_corner(Square s) {
   return (s == SQ_A1 || s == SQ_H1 || s == SQ_A8 || s == SQ_H8);
 }
 
+
+// Trivial progress: as long as there is only one legal move, make that move
+// (But at most a limited number of times, to avoid infinite loops)
+
+void UTIL::trivial_progress(Position& pos, StateInfo& st, int repetitions) {
+  if (MoveList<LEGAL>(pos).size() == 1 && repetitions > 0)
+    for (const auto& m : MoveList<LEGAL>(pos)) {
+      pos.do_move(m, st);
+      trivial_progress(pos, st, repetitions - 1);
+    }
+}
+
+
 // The next function computes the knight distance between two squares.
 // Note that this can be calculated from just the rank distance and
 // the file distance between the squares, following the tables:
@@ -198,4 +211,3 @@ void KnightDistance::init() {
 int KnightDistance::get(Square x, Square y) {
   return KnightDistanceTable[index(x, y)];
 }
-

--- a/src/util.h
+++ b/src/util.h
@@ -30,6 +30,8 @@ namespace UTIL {
 
   bool is_corner(Square s);
 
+  void trivial_progress(Position& pos, StateInfo& st, int repetitions);
+
 } // namespace UTIL
 
 


### PR DESCRIPTION
Before the conditions on the material to decide whether semistatic
analysis is performed.

(Problem identified by dlbbld, it affected to e.g. this position:
7k/q5Q1/p4PPK/6PP/8/5P2/8/8 b - - 16 40
which could not be correctly classified by "quick".)